### PR TITLE
Hotfix/fetch user

### DIFF
--- a/Present/Commands/GiveawayCommand.Redraw.cs
+++ b/Present/Commands/GiveawayCommand.Redraw.cs
@@ -41,22 +41,26 @@ internal sealed partial class GiveawayCommand
         {
             foreach (string keepId in keepIds.Split((char[]?) null, StringSplitOptions.RemoveEmptyEntries))
             {
-                if (ulong.TryParse(keepId, out ulong userId) &&
-                    _giveawayService.ValidateUser(userId, guild, out DiscordMember? member))
-                    keep.Add(member);
-                else
+                if (!ulong.TryParse(keepId, out ulong userId))
+                {
                     invalidKeepIds.Add(keepId);
+                    continue;
+                }
+
+                DiscordMember? member = await _giveawayService.ValidateUserAsync(userId, giveaway).ConfigureAwait(false);
+                if (member is null) invalidKeepIds.Add(keepId);
+                else keep.Add(member);
             }
         }
 
-        IReadOnlyList<DiscordMember> winners = _giveawayService.SelectWinners(giveaway, keep);
+        IReadOnlyList<DiscordMember> winners = await _giveawayService.SelectWinnersAsync(giveaway, keep).ConfigureAwait(false);
         await _giveawayService.UpdateWinnersAsync(giveaway, winners).ConfigureAwait(false);
 
         await _giveawayService.EditGiveawayAsync(giveaway).ConfigureAwait(false);
         await _giveawayService.UpdateGiveawayLogMessageAsync(giveaway).ConfigureAwait(false);
         await _giveawayService.UpdateGiveawayPublicMessageAsync(giveaway).ConfigureAwait(false);
 
-        embed = _giveawayService.CreateGiveawayInformationEmbed(giveaway);
+        embed = await _giveawayService.CreateGiveawayInformationEmbedAsync(giveaway).ConfigureAwait(false);
         embed.WithColor(DiscordColor.Green);
         embed.WithTitle(EmbedStrings.GiveawayEdited_Title);
 

--- a/Present/Commands/GiveawayCommand.SetWinners.cs
+++ b/Present/Commands/GiveawayCommand.SetWinners.cs
@@ -47,7 +47,7 @@ internal sealed partial class GiveawayCommand
         await _giveawayService.UpdateGiveawayLogMessageAsync(giveaway).ConfigureAwait(false);
         await _giveawayService.UpdateGiveawayPublicMessageAsync(giveaway).ConfigureAwait(false);
 
-        embed = _giveawayService.CreateGiveawayInformationEmbed(giveaway);
+        embed = await _giveawayService.CreateGiveawayInformationEmbedAsync(giveaway).ConfigureAwait(false);
         embed.WithColor(DiscordColor.Green);
         embed.WithTitle(EmbedStrings.GiveawayEdited_Title);
         await context.CreateResponseAsync(embed).ConfigureAwait(false);

--- a/Present/Commands/GiveawayCommand.View.cs
+++ b/Present/Commands/GiveawayCommand.View.cs
@@ -26,7 +26,7 @@ internal sealed partial class GiveawayCommand
             return;
         }
 
-        embed = _giveawayService.CreateGiveawayInformationEmbed(giveaway);
+        embed = await _giveawayService.CreateGiveawayInformationEmbedAsync(giveaway).ConfigureAwait(false);
         embed.WithTitle(EmbedStrings.GiveawayInformation);
 
         await context.CreateResponseAsync(embed).ConfigureAwait(false);

--- a/Present/Data/EntityConfigurations/GiveawayConfiguration.cs
+++ b/Present/Data/EntityConfigurations/GiveawayConfiguration.cs
@@ -27,6 +27,8 @@ internal sealed class GiveawayConfiguration : IEntityTypeConfiguration<Giveaway>
         builder.Property(e => e.Description);
         builder.Property(e => e.ImageUri).HasConversion<UriToStringConverter>();
         builder.Property(e => e.Entrants).HasConversion<UInt64ListToBytesConverter>();
+        builder.Property(e => e.ExcludedRoles).HasConversion<UInt64ListToBytesConverter>();
+        builder.Property(e => e.ExcludedUsers).HasConversion<UInt64ListToBytesConverter>();
         builder.Property(e => e.WinnerCount);
         builder.Property(e => e.WinnerIds).HasConversion<UInt64ListToBytesConverter>();
         builder.Property(e => e.MessageId);

--- a/Present/Data/Giveaway.cs
+++ b/Present/Data/Giveaway.cs
@@ -42,6 +42,18 @@ internal sealed class Giveaway : IEquatable<Giveaway>
     public DateTimeOffset EndTime { get; set; }
 
     /// <summary>
+    ///     Gets or sets the list of excluded role IDs for this giveaway.
+    /// </summary>
+    /// <value>A <see cref="List{T}" /> of <see cref="ulong" /> representing the excluded role IDs.</value>
+    public List<ulong> ExcludedRoles { get; set; } = new();
+
+    /// <summary>
+    ///     Gets or sets the list of excluded user IDs for this giveaway.
+    /// </summary>
+    /// <value>A <see cref="List{T}" /> of <see cref="ulong" /> representing the excluded user IDs.</value>
+    public List<ulong> ExcludedUsers { get; set; } = new();
+
+    /// <summary>
     ///     Gets or sets the guild ID of the giveaway.
     /// </summary>
     /// <value>The guild ID.</value>

--- a/Present/Present.csproj
+++ b/Present/Present.csproj
@@ -31,18 +31,18 @@
         <PackageReference Include="DSharpPlus" Version="4.3.0"/>
         <PackageReference Include="DSharpPlus.SlashCommands" Version="4.3.0"/>
         <PackageReference Include="Humanizer.Core" Version="2.14.1"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.1">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.1"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0"/>
-        <PackageReference Include="NLog" Version="5.1.0"/>
-        <PackageReference Include="NLog.Extensions.Logging" Version="5.2.0"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1"/>
+        <PackageReference Include="NLog" Version="5.1.2"/>
+        <PackageReference Include="NLog.Extensions.Logging" Version="5.2.2"/>
         <PackageReference Include="SmartFormat.NET" Version="3.2.0"/>
-        <PackageReference Include="X10D" Version="3.2.0-nightly.149"/>
-        <PackageReference Include="X10D.DSharpPlus" Version="3.2.0-nightly.149"/>
-        <PackageReference Include="X10D.Hosting" Version="3.2.0-nightly.149"/>
+        <PackageReference Include="X10D" Version="3.2.0-nightly.152"/>
+        <PackageReference Include="X10D.DSharpPlus" Version="3.2.0-nightly.152"/>
+        <PackageReference Include="X10D.Hosting" Version="3.2.0-nightly.152"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Present/Services/ActiveGiveawayService.cs
+++ b/Present/Services/ActiveGiveawayService.cs
@@ -147,7 +147,7 @@ internal sealed class ActiveGiveawayService : BackgroundService
         giveaway.EndHandled = true;
         RemoveActiveGiveaway(giveaway);
 
-        IReadOnlyList<DiscordMember> winners = _giveawayService.SelectWinners(giveaway);
+        IReadOnlyList<DiscordMember> winners = await _giveawayService.SelectWinnersAsync(giveaway).ConfigureAwait(false);
         Logger.Info($"Selected {"winner".ToQuantity(winners.Count)} for giveaway {giveaway.Id} ({giveaway.Title})");
         foreach (DiscordMember winner in winners)
             Logger.Info(winner);

--- a/Present/Services/GiveawayService.cs
+++ b/Present/Services/GiveawayService.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NLog;
 using SmartFormat;
-using X10D.Collections;
 using X10D.Core;
 using X10D.DSharpPlus;
 
@@ -169,7 +168,7 @@ internal sealed class GiveawayService : BackgroundService
     /// <param name="giveaway">The giveaway whose information to fetch.</param>
     /// <returns>A <see cref="DiscordEmbedBuilder" />, populated with information from <paramref name="giveaway" />.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="giveaway" /> is <see langword="null" />.</exception>
-    public DiscordEmbedBuilder CreateGiveawayInformationEmbed(Giveaway giveaway)
+    public async Task<DiscordEmbedBuilder> CreateGiveawayInformationEmbedAsync(Giveaway giveaway)
     {
         ArgumentNullException.ThrowIfNull(giveaway);
 
@@ -188,7 +187,14 @@ internal sealed class GiveawayService : BackgroundService
         var jumpLink = new Uri($"https://discord.com/channels/{giveaway.GuildId}/{giveaway.ChannelId}/{giveaway.MessageId}");
         string conjugatedEnd = giveaway.EndTime < DateTimeOffset.UtcNow ? EmbedStrings.Ended : EmbedStrings.Ends;
         var entrantsCount = giveaway.Entrants.Count.ToString("N0");
-        var excludedEntrantsCount = giveaway.Entrants.CountWhereNot(e => ValidateUser(e, guild, out _)).ToString("N0");
+        var excludedEntrantsCount = 0;
+        foreach (ulong entrantId in giveaway.Entrants)
+        {
+            DiscordMember? member = await ValidateUserAsync(entrantId, giveaway).ConfigureAwait(false);
+            if (member is null) excludedEntrantsCount++;
+        }
+
+        var excludedEntrants = excludedEntrantsCount.ToString("N0");
 
         embed.AddField(EmbedStrings.Title, giveaway.Title);
         embed.AddField(EmbedStrings.Description, description);
@@ -199,7 +205,7 @@ internal sealed class GiveawayService : BackgroundService
         embed.AddField(conjugatedEnd, Formatter.Timestamp(giveaway.EndTime), true);
         embed.AddField(EmbedStrings.Creator, MentionUtility.MentionUser(giveaway.CreatorId), true);
         embed.AddField(EmbedStrings.Entrants, entrantsCount, true);
-        embed.AddField(EmbedStrings.ExcludedEntrants, excludedEntrantsCount, true);
+        embed.AddField(EmbedStrings.ExcludedEntrants, excludedEntrants, true);
         embed.AddFieldIf(giveaway.ImageUri is not null, "Image", () => Formatter.MaskedUrl("View", giveaway.ImageUri), true);
 
         List<ulong> winnerIds = giveaway.WinnerIds;
@@ -218,11 +224,11 @@ internal sealed class GiveawayService : BackgroundService
     /// <param name="giveaway">The giveaway whose log embed to return.</param>
     /// <returns>The log embed.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="giveaway" /> is <see langword="null" />.</exception>
-    public DiscordEmbed CreateGiveawayLogEmbed(Giveaway giveaway)
+    public async Task<DiscordEmbed> CreateGiveawayLogEmbedAsync(Giveaway giveaway)
     {
         ArgumentNullException.ThrowIfNull(giveaway);
 
-        DiscordEmbedBuilder embed = CreateGiveawayInformationEmbed(giveaway);
+        DiscordEmbedBuilder embed = await CreateGiveawayInformationEmbedAsync(giveaway).ConfigureAwait(false);
         embed.WithTitle(EmbedStrings.GiveawayCreated_Title_NoEmoji);
         embed.WithColor(DiscordColor.Green);
         return embed;
@@ -425,7 +431,7 @@ internal sealed class GiveawayService : BackgroundService
             return;
         }
 
-        DiscordEmbedBuilder embed = CreateGiveawayInformationEmbed(giveaway);
+        DiscordEmbedBuilder embed = await CreateGiveawayInformationEmbedAsync(giveaway).ConfigureAwait(false);
         embed.WithTitle(EmbedStrings.GiveawayCreated_Title_NoEmoji);
         embed.WithColor(DiscordColor.Green);
 
@@ -461,7 +467,14 @@ internal sealed class GiveawayService : BackgroundService
             description = $"{description[..1021]}...";
 
         var entrantsCount = giveaway.Entrants.Count.ToString("N0");
-        var excludedEntrantsCount = giveaway.Entrants.CountWhereNot(e => ValidateUser(e, guild, out _)).ToString("N0");
+        var excludedEntrantsCount = 0;
+        foreach (ulong entrantId in giveaway.Entrants)
+        {
+            DiscordMember? member = await ValidateUserAsync(entrantId, giveaway).ConfigureAwait(false);
+            if (member is null) excludedEntrantsCount++;
+        }
+
+        var excludedEntrants = excludedEntrantsCount.ToString("N0");
 
         embed.AddField(EmbedStrings.Title, giveaway.Title);
         embed.AddField(EmbedStrings.Description, description);
@@ -469,7 +482,7 @@ internal sealed class GiveawayService : BackgroundService
         embed.AddField(EmbedStrings.NumberOfWinners, giveaway.WinnerCount, true);
         embed.AddField(EmbedStrings.Duration, (giveaway.EndTime - giveaway.StartTime).Humanize(), true);
         embed.AddField(EmbedStrings.Entrants, entrantsCount, true);
-        embed.AddField(EmbedStrings.ExcludedEntrants, excludedEntrantsCount, true);
+        embed.AddField(EmbedStrings.ExcludedEntrants, excludedEntrants, true);
 
         var winners = new List<DiscordMember>();
         foreach (ulong winnerId in giveaway.WinnerIds)
@@ -518,7 +531,8 @@ internal sealed class GiveawayService : BackgroundService
     ///     The selected winners of the giveaway. The returned list does not include invalid users, users which are no longer in
     ///     the guild, or users with at least one of the excluded role IDs.
     /// </returns>
-    public IReadOnlyList<DiscordMember> SelectWinners(Giveaway giveaway, IEnumerable<DiscordMember>? winnersToKeep = null)
+    public async Task<IReadOnlyList<DiscordMember>> SelectWinnersAsync(Giveaway giveaway,
+        IEnumerable<DiscordMember>? winnersToKeep = null)
     {
         ArgumentNullException.ThrowIfNull(giveaway);
 
@@ -536,7 +550,8 @@ internal sealed class GiveawayService : BackgroundService
             // in the event that there are zero valid winners
             entrants.Remove(randomUserId);
 
-            if (ValidateUser(randomUserId, guild, out DiscordMember? member))
+            DiscordMember? member = await ValidateUserAsync(randomUserId, giveaway).ConfigureAwait(false);
+            if (member is not null)
                 winners.Add(member);
         }
 
@@ -595,7 +610,7 @@ internal sealed class GiveawayService : BackgroundService
             return;
         }
 
-        DiscordEmbed embed = CreateGiveawayLogEmbed(giveaway);
+        DiscordEmbed embed = await CreateGiveawayLogEmbedAsync(giveaway).ConfigureAwait(false);
         await message.ModifyAsync(embed).ConfigureAwait(false);
     }
 
@@ -667,21 +682,25 @@ internal sealed class GiveawayService : BackgroundService
     ///     Validates that the user with the specified ID is a valid participant of giveaways in the specified guild.
     /// </summary>
     /// <param name="userId">The ID of the user to validate.</param>
-    /// <param name="guild">The guild in which to perform the validation check.</param>
-    /// <param name="member">
-    ///     When this method returns, contains the <see cref="DiscordMember" /> with the ID <paramref name="userId" /> that is a
-    ///     member of <paramref name="guild" />.
-    /// </param>
+    /// <param name="giveaway">The giveaway used for validation.</param>
     /// <returns>
-    ///     <see langword="true" /> if the user with the ID <paramref name="userId" /> is a valid a participant of giveaways in
-    ///     <paramref name="guild" />; otherwise, <see langword="false" />. 
+    ///     A <see cref="DiscordMember" /> object encapsulating the member as part of the guild in <paramref name="giveaway" />,
+    ///     if this user satisfies the giveaway requirements; otherwise, <see langword="null" />.
     /// </returns>
-    /// <exception cref="ArgumentNullException"><paramref name="guild" /> is <see langword="null" />.</exception>
-    public bool ValidateUser(ulong userId, DiscordGuild guild, [NotNullWhen(true)] out DiscordMember? member)
+    /// <exception cref="ArgumentNullException"><paramref name="giveaway" /> is <see langword="null" />.</exception>
+    public async Task<DiscordMember?> ValidateUserAsync(ulong userId, Giveaway giveaway)
     {
-        ArgumentNullException.ThrowIfNull(guild);
-        member = null;
-        return userId != 0 && guild.Members.TryGetValue(userId, out member) && ValidateMember(member, guild);
+        ArgumentNullException.ThrowIfNull(giveaway);
+
+        DiscordGuild guild = await _discordClient.GetGuildAsync(giveaway.GuildId).ConfigureAwait(false);
+        DiscordMember? member = await guild.GetMemberOrNullAsync(userId).ConfigureAwait(false);
+
+        if (member is null) return null;
+        if (!ValidateMember(member, guild)) return null;
+        if (giveaway.ExcludedUsers.Contains(userId)) return null;
+        if (member.Roles.Any(r => giveaway.ExcludedRoles.Contains(r.Id))) return null;
+
+        return member;
     }
 
     private async Task UpdateFromDatabaseAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Fetch user fresh, rather than using cache, when validating. This should hopefully fix the issue of member selection.

This change fundamentally breaks older versions, and therefore requires an EF migration or reset.